### PR TITLE
Clean row values

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Add to your Package.swift dependencies:
 
 ```
-.package(url: "https://github.com/zackify/swift-csv.git", from: "0.1.0")
+.package(url: "https://github.com/zackify/swift-csv.git", from: "0.2.0")
 ```
 
 ## Example

--- a/Sources/SwiftCSV/SwiftCSV.swift
+++ b/Sources/SwiftCSV/SwiftCSV.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 public struct SwiftCSV {
   public static func generate<Row>(_ rows: [Row], renderRow: (RowRenderer<Row>) -> [Cell]) -> String {
     let columns = Columns()
@@ -26,7 +28,12 @@ public struct SwiftCSV {
 }
 
 func arrayToCSVRow(_ strings: [String]) -> String {
-  return strings.map { 
-    "\"\($0)\"" 
+  return strings.map {
+    let cleanString = $0
+      .replacingOccurrences(of: "\"", with: "\"\"")
+      .replacingOccurrences(of: "\r\n", with: " ")
+      .replacingOccurrences(of: "\r", with: " ")
+      .replacingOccurrences(of: "\n", with: " ")
+    return "\"\(cleanString)\""
   }.joined(separator: ",")
 }

--- a/Tests/SwiftCSVTests/tests.swift
+++ b/Tests/SwiftCSVTests/tests.swift
@@ -23,7 +23,7 @@ let testRows = [
     ]
   ),
   Person(
-    id: "1", 
+    id: "2", 
     name: "Bob", 
     phoneNumber: "483884828", 
     addresses: [
@@ -31,8 +31,16 @@ let testRows = [
       Address(street: "California"),
       Address(street: "Texas"),
     ]
+  ),
+  Person(
+    id: "3",
+    name: "Jim",
+    phoneNumber: "5554443333",
+    addresses: [
+      Address(street: "Idaho,\n not \"Ohio\"")
+    ]
   )
-] 
+]
 
 final class swift_csvTests: XCTestCase {
     func testExample() {
@@ -53,6 +61,7 @@ final class swift_csvTests: XCTestCase {
             "Name","Address","Address #2","Address #3","Phone number"
             "Test","New York","California","","5493939393"
             "Bob","Montana","California","Texas","483884828"
+            "Jim","Idaho,  not \"\"Ohio\"\"","","","5554443333"
             """
         )    }
 


### PR DESCRIPTION
Replace double quotes and return characters.

Input:
```
[
  Person(
    id: "1", 
    name: "Test", 
    phoneNumber: "5493939393", 
    addresses: [
      Address(street: "New York"),
      Address(street: "California"),
    ]
  ),
  Person(
    id: "2", 
    name: "Bob", 
    phoneNumber: "483884828", 
    addresses: [
      Address(street: "Montana"),
      Address(street: "California"),
      Address(street: "Texas"),
    ]
  ),
  Person(
    id: "3",
    name: "Jim",
    phoneNumber: "5554443333",
    addresses: [
      Address(street: "Idaho,\n not \"Ohio\"")
    ]
  )
]
```

Output:
```
"Name","Address","Address #2","Address #3","Phone number"
"Test","New York","California","","5493939393"
"Bob","Montana","California","Texas","483884828"
"Jim","Idaho,  not ""Ohio""","","","5554443333"
```
![Screenshot 2024-02-14 at 11 12 58 AM](https://github.com/zackify/swift-csv/assets/103135/f8015013-ee66-4c0d-b83d-fda3666c8a85)
